### PR TITLE
fix: speed up MONA output processing

### DIFF
--- a/logaut/backends/common/process_mona_output.py
+++ b/logaut/backends/common/process_mona_output.py
@@ -228,5 +228,5 @@ def parse_automaton(output: MONAOutput) -> SymbolicDFA:
             symbolic_guard = from_set_of_guards_to_sympy_formula(
                 guards, output.variable_names
             )
-            automaton.add_transition((start_state, symbolic_guard, end_state))
+            automaton._transition_function.setdefault(start_state, {})[end_state] = symbolic_guard
     return automaton

--- a/logaut/backends/common/process_mona_output.py
+++ b/logaut/backends/common/process_mona_output.py
@@ -228,5 +228,7 @@ def parse_automaton(output: MONAOutput) -> SymbolicDFA:
             symbolic_guard = from_set_of_guards_to_sympy_formula(
                 guards, output.variable_names
             )
-            automaton._transition_function.setdefault(start_state, {})[end_state] = symbolic_guard
+            automaton._transition_function.setdefault(start_state, {})[
+                end_state
+            ] = symbolic_guard
     return automaton


### PR DESCRIPTION
## Proposed changes

fix: speed up MONA output processing

Since we already know MONA gives disjoint transitions, we can avoid adding transitions one by one to `SymbolicDFA`.

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/master/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a